### PR TITLE
Fix landing page incorrect redirect to unused login url

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (decodedUser.exp < currentTime) {
       store.dispatch(logout());
-      window.location.href = '/login';
+      window.location.href = '/';
     }
   } else {
     store = configureStore({});


### PR DESCRIPTION
Originally, if you went to boy and tiger for the first time, it would redirect you to /login, which is a blank page. 